### PR TITLE
Fix generate signature when GET method

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -46,7 +46,7 @@ func (a *DoitpayAuth) GetAccessToken(ctx context.Context) (string, error) {
             return "", err
         }
 
-        transport := httptransport.New(a.config.Host, a.config.BasePath, []string{"http"})
+        transport := httptransport.New(a.config.Host, a.config.BasePath, []string{"https", "http"})
         authService := client.New(transport, strfmt.Default).Authentication
 
         resp, err := authService.AccessToken(&authentication.AccessTokenParams{

--- a/authentication.go
+++ b/authentication.go
@@ -46,7 +46,7 @@ func (a *DoitpayAuth) GetAccessToken(ctx context.Context) (string, error) {
             return "", err
         }
 
-        transport := httptransport.New(a.config.Host, a.config.BasePath, []string{"https", "http"})
+        transport := httptransport.New(a.config.Host, a.config.BasePath, []string{"http"})
         authService := client.New(transport, strfmt.Default).Authentication
 
         resp, err := authService.AccessToken(&authentication.AccessTokenParams{
@@ -95,10 +95,15 @@ func (a *DoitpayAuth) AuthenticateRequest(req runtime.ClientRequest, reg strfmt.
         return err
     }
 
+    endpoint := req.GetPath()
+    if params := req.GetQueryParams(); len(params) > 0 {
+        endpoint = endpoint + "?" + params.Encode()
+    }
+
     // Generate signature
     signature, err := signature.GenerateSNAPSymmetricSignature(
         req.GetMethod(),
-        req.GetPath(),
+        endpoint,
         accessToken,
         a.config.ClientSecret,
         timestamp,

--- a/pkg/signature/signature.go
+++ b/pkg/signature/signature.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -34,13 +35,16 @@ func GenerateSNAPSymmetricSignature(httpMethod, endpointUrl, accessToken, client
 	r := bytes.NewBuffer(body)
 	var w bytes.Buffer
 
-	if err := minify.Minify(nil, &w, r, nil); err != nil {
-		return "", err
+	var datahashString string
+	if strings.EqualFold(httpMethod, http.MethodGet) {
+		datahashString = ""
+	} else {
+		if err := minify.Minify(nil, &w, r, nil); err != nil {
+			return "", err
+		}
+		datahash := sha256.Sum256(w.Bytes())
+		datahashString = strings.ToLower(hex.EncodeToString(datahash[:]))
 	}
-
-	datahash := sha256.Sum256(w.Bytes())
-
-	datahashString := strings.ToLower(hex.EncodeToString(datahash[:]))
 
 	stringToSign := fmt.Sprintf("%s:%s:%s:%s:%s",
 		strings.ToTitle(httpMethod),


### PR DESCRIPTION
### Pull Request Description

#### Summary of Changes
This pull request includes modifications to the `authentication.go` and `pkg/signature/signature.go` files. The main changes are as follows:

1. **authentication.go**:
   - Enhanced the `AuthenticateRequest` function to include query parameters in the endpoint URL for generating the signature.

2. **pkg/signature/signature.go**:
   - Added handling for GET requests in the `GenerateSNAPSymmetricSignature` function to avoid hashing the body content.
   - Introduced a condition to set the data hash string to an empty value for GET requests.