### PR TITLE
Fix: use with* pattern for differentiate setting private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The official Doitpay Go SDK offers an easy and user-friendly method to access Doitpay's REST API in applications coded in Go.
 
-* Package version: 0.9.3
+* Package version: 1.0.0
 
 # Getting Started
 
@@ -11,24 +11,24 @@ The official Doitpay Go SDK offers an easy and user-friendly method to access Do
 Install doitpay-go in your Go application:
 
 ```shell
-go get github.com/automotechnologies/doitpay-go/v2
+go get github.com/automotechnologies/doitpay-go
 ```
 
 Place the package in your project directory and include the following in the import:
 
 ```golang
-import doitpay "github.com/automotechnologies/doitpay-go/v2"
+import doitpay "github.com/automotechnologies/doitpay-go"
 ```
 
 ## Authorization
 
-To utilize the SDK, initialize it with your client key, partner ID, and private key path. You can get these credentials from the [Doitpay Dashboard](https://dashboard.doitpay.co). If you haven't, you can register for a free Dashboard account [here](https://dashboard.doitpay.co/register).
+To utilize the SDK, initialize it with your client key and partner ID. You can get these credentials from the [Doitpay Dashboard](https://dashboard.doitpay.co). If you haven't, you can register for a free Dashboard account [here](https://dashboard.doitpay.co/register).
 
 ```golang
 dtp, err := doitpay.NewClient(
-    "YOUR_CLIENT_KEY",
     "YOUR_PARTNER_ID",
-    "path/to/private_key.pem",
+    "YOUR_CLIENT_SECRET",
+    doitpay.WithPrivateKeyPath("path/to/private/key.pem"), //  specify private key path or private key bytes
     doitpay.WithHost("api.doitpay.co"), // Optional: specify host
 )
 if err != nil {
@@ -43,8 +43,8 @@ if err != nil {
 ```golang
 import (
     "context"
-    "github.com/automotechnologies/doitpay-go/v2"
-    "github.com/automotechnologies/doitpay-go/v2/models"
+    "github.com/automotechnologies/doitpay-go"
+    "github.com/automotechnologies/doitpay-go/models"
     "github.com/oklog/ulid"
     "time"
 )

--- a/examples/main.go
+++ b/examples/main.go
@@ -53,7 +53,7 @@ func ParsePrivateKey(private []byte) (*rsa.PrivateKey, error) {
 }
 
 func main() {
-	dtp, err := doitpay.NewClient("01J20VM8TNRK9VBMGJAQDBSF8X", "01J20VM8W11EP9M6KBHHJZMHPW", PrivateKeyPath, doitpay.WithHost("localhost:8000"))
+	dtp, err := doitpay.NewClient("01J20VM8TNRK9VBMGJAQDBSF8X", "01J20VM8W11EP9M6KBHHJZMHPW", doitpay.WithPrivateKeyPath(PrivateKeyPath), doitpay.WithHost("localhost:8000"))
 	if err != nil {
 		log.Fatalf("Failed to create DTP client: %v", err)
 	}


### PR DESCRIPTION
## Summary

This pull request introduces enhancements to the `doitpay-go` client configuration by adding new options for setting the private key. Specifically, it adds support for setting the private key path and private key bytes through `ClientOption` functions.

## Changes

1. Added `WithPrivateKeyPath` function to set a custom private key path.
2. Added `WithPrivateKeyBytes` function to set custom private key bytes.
3. Updated the `ClientConfig` struct to include `privateKeyPath` and `privateKeyBytes` fields.
4. Modified the `NewClient` function to accommodate the new private key configurations and prioritize the use of `privateKeyPath`.

## Code Changes

### New Functions

- `WithPrivateKeyPath(privateKeyPath string) ClientOption`
  - Allows setting a custom private key path.
- `WithPrivateKeyBytes(privateKeyBytes []byte) ClientOption`
  - Allows setting custom private key bytes.

### Updated Structures

- `ClientConfig`
  - Added fields `privateKeyPath` and `privateKeyBytes`.

### Modified Functions

- `NewClient(partnerID, clientSecret string, opts ...ClientOption) (*DoitpayClient, error)`
  - Updated to handle the new private key configurations, prioritizing `privateKeyPath`.

## Motivation

The changes provide more flexibility in setting the private key for the `doitpay-go` client, making it easier to configure the client in different environments and use cases.
