### PR TITLE
Add ability to customize http scheme

### DIFF
--- a/authentication.go
+++ b/authentication.go
@@ -3,13 +3,14 @@ package doitpay
 import (
 	"bytes"
 	"context"
-	"github.com/pkg/errors"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/automotechnologies/doitpay-go/client"
 	"github.com/automotechnologies/doitpay-go/client/authentication"
@@ -62,7 +63,7 @@ func (a *DoitpayAuth) GetAccessToken(ctx context.Context) (string, error) {
 			return "", err
 		}
 
-		transport := httptransport.New(a.config.Host, a.config.BasePath, []string{"https", "http"})
+		transport := httptransport.New(a.config.Host, a.config.BasePath, []string{a.config.Scheme})
 		authService := client.New(transport, strfmt.Default).Authentication
 
 		resp, err := authService.AccessToken(&authentication.AccessTokenParams{

--- a/doitpay.go
+++ b/doitpay.go
@@ -38,11 +38,17 @@ func WithPrivateKeyBytes(privateKeyBytes []byte) ClientOption {
 }
 
 
-
 // WithBasePath sets a custom base path
 func WithBasePath(basePath string) ClientOption {
 	return func(c *ClientConfig) {
 		c.BasePath = basePath
+	}
+}
+
+// WithScheme sets a custom scheme
+func WithScheme(scheme string) ClientOption {
+	return func(c *ClientConfig) {
+		c.Scheme = scheme
 	}
 }
 
@@ -75,6 +81,7 @@ type ClientConfig struct {
 	PrivateKey   *rsa.PrivateKey
 	privateKeyPath string
 	privateKeyBytes []byte
+	Scheme string
 }
 
 // NewClient creates a new authenticated client with optional configurations
@@ -111,6 +118,11 @@ func NewClient(partnerID, clientSecret string,  opts ...ClientOption) (*DoitpayC
 		return nil, fmt.Errorf("failed to decode private key")
 	}
 
+	// validate scheme
+	if cfg.Scheme == "" {
+		cfg.Scheme = "https"
+	}
+
 	if privatePem.Type != "RSA PRIVATE KEY" && privatePem.Type != "ENCRYPTED PRIVATE KEY" && privatePem.Type != "PRIVATE KEY" {
 		return nil, fmt.Errorf("private key is not a valid PEM file")
 	}
@@ -127,7 +139,7 @@ func NewClient(partnerID, clientSecret string,  opts ...ClientOption) (*DoitpayC
 	cfg.PrivateKey = rsaPrivateKey
 
 	// Create transport with auth
-	transport := httptransport.New(cfg.Host, cfg.BasePath, []string{"https", "http"})
+	transport := httptransport.New(cfg.Host, cfg.BasePath, []string{cfg.Scheme})
 
 	// Need to use default authentication that follows SNAP flows.
 	transport.DefaultAuthentication = NewDoitpayAuth(cfg)


### PR DESCRIPTION
#### Summary:
This pull request introduces enhancements and fixes to the `doitpay-go` library, focusing on improving flexibility in configuring the HTTP transport scheme and cleaning up imports.

---

#### Changes:
1. **Transport Scheme Customization**:
   - Added a new client configuration option `WithScheme` to allow users to set a custom scheme (e.g., "http" or "https").
   - Updated the `ClientConfig` struct to include a new `Scheme` field.
   - Updated transport initialization in `NewClient` and `GetAccessToken` to use the custom scheme (`cfg.Scheme` or `a.config.Scheme`).

2. **Default Scheme Validation**:
   - Ensured that the `Scheme` field defaults to "https" if not provided during client initialization.

3. **Import Cleanup**:
   - Rearranged imports for better readability.
   - Fixed misplaced `github.com/pkg/errors` import.

4. **New Functionality**:
   - Added `WithScheme` as a new `ClientOption` for setting a custom scheme.

5. **Code Improvements**:
   - Updated `httptransport.New` calls to use the `Scheme` configuration instead of hardcoding `{"https", "http"}`.

---

#### Files Modified:
1. **`authentication.go`**:
   - Fixed import order.
   - Updated `httptransport.New` call to use `a.config.Scheme`.

2. **`doitpay.go`**:
   - Introduced `WithScheme` function for setting a custom scheme.
   - Added `Scheme` field to `ClientConfig`.
   - Validated the `Scheme` field in `NewClient`.
   - Updated `httptransport.New` to use `cfg.Scheme`.

---

#### Motivation:
The changes aim to provide developers with more flexibility by allowing them to configure the transport scheme. Additionally, defaulting to "https" ensures security while maintaining backward compatibility.
